### PR TITLE
Docs: Add Terraform Acceptance Tests Section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ export CODEFRESH_API_KEY='xyz'
 
 ## Testing the Provider
 
+```bash
+export TF_ACC="test" 
+export CODEFRESH_API_KEY=[YOUR API TOKEN]
+go test -v ./...
+```
+
 ## License
 
 Copyright 2022 Codefresh.


### PR DESCRIPTION
## What

* Add section in README on running acceptance tests.

## Why

* This section is currently empty

## Notes

N/A
